### PR TITLE
Release idle database leases from the MCP server

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -15,7 +15,8 @@
       "env": {
         "IDA_NEXUS_ID": "${IDA_NEXUS_ID:-}",
         "IDAUSR": "${IDAUSR:-}",
-        "IDA_NEXUS_STATE_DIR": "${IDA_NEXUS_STATE_DIR:-}"
+        "IDA_NEXUS_STATE_DIR": "${IDA_NEXUS_STATE_DIR:-}",
+        "IDA_MCP_IDLE_TIMEOUT": "${IDA_MCP_IDLE_TIMEOUT:-}"
       }
     }
   },

--- a/.codex-plugin/mcp.json
+++ b/.codex-plugin/mcp.json
@@ -7,6 +7,11 @@
       "--agent=codex"
     ],
     "cwd": ".",
-    "env_vars": ["IDA_NEXUS_ID", "IDAUSR", "IDA_NEXUS_STATE_DIR"]
+    "env_vars": [
+      "IDA_NEXUS_ID",
+      "IDAUSR",
+      "IDA_NEXUS_STATE_DIR",
+      "IDA_MCP_IDLE_TIMEOUT"
+    ]
   }
 }

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,48 @@
+name: Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: checks-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  UV_PYTHON: "3.13"
+  # Keep this aligned with the release workflow.
+  UV_VERSION: "0.10.6"
+
+jobs:
+  python:
+    name: Lint and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python with uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install Python
+        run: uv python install "$UV_PYTHON"
+
+      - name: Sync dependencies
+        run: uv sync --locked
+
+      - name: Lint
+        run: uv run ruff check ida_mcp tests
+
+      - name: Check formatting
+        run: uv run ruff format --check ida_mcp tests
+
+      - name: Test
+        run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -64,6 +64,31 @@ omp plugin install github:HexRaysSA/ida-mcp#latest
 omp plugin upgrade
 ```
 
+### Idle database release
+
+An agent that opens a database and never closes it would otherwise keep an IDA
+worker, and its unpacked IDB, alive for the whole agent session. IDA MCP
+therefore releases its lease on any database it has not used for 30 minutes:
+the worker saves the database, closes it, and exits, so an idle machine can be
+suspended and no IDB stays open longer than the work needs it.
+
+This is invisible to agents. The next tool call that uses the database reopens
+it under the same `instance_id`, so nothing an agent is holding goes stale. GUI
+databases are never released, because a GUI instance is not kept alive by MCP
+leases.
+
+Pass `--idle-timeout` to choose a different period, or to turn the behavior
+off:
+
+```bash
+ida-mcp --agent=my-agent --idle-timeout=300   # five minutes
+ida-mcp --agent=my-agent --idle-timeout=off   # never release
+```
+
+`IDA_MCP_IDLE_TIMEOUT` sets the same value for hosts that configure MCP servers
+through the environment rather than through command-line arguments. The plugin
+installations above forward it.
+
 ### Other agents
 
 Configure a regular stdio MCP server in your MCP JSON configuration:
@@ -84,15 +109,12 @@ Configure a regular stdio MCP server in your MCP JSON configuration:
 ```
 
 `uvx` resolves the latest stable `ida-nexus` release from PyPI, so this
-configuration does not need to be updated for each release.
+configuration does not need to be updated for each release. It runs the IDA
+Nexus MCP server directly, so it keeps its database leases until the agent
+closes them or the server exits; idle release is part of `ida-mcp`.
 
 `--agent=my-agent` is a human-chosen label (like `claude-code`, `cursor`,
 `my-custom-agent`, etc.) used to differentiate sessions in a metrics dashboard.
-
-We tested the following clients, but any MCP client should work similarly:
-
-- [Antigravity](https://coder.google.com/)
-- [LM Studio](https://lmstudio.ai/)
 
 ### Example Usage
 

--- a/ida-mcp.ts
+++ b/ida-mcp.ts
@@ -215,6 +215,9 @@ export default function idaNexus(pi: ExtensionAPI) {
         ...(process.env.IDA_NEXUS_STATE_DIR
           ? { IDA_NEXUS_STATE_DIR: process.env.IDA_NEXUS_STATE_DIR }
           : {}),
+        ...(process.env.IDA_MCP_IDLE_TIMEOUT
+          ? { IDA_MCP_IDLE_TIMEOUT: process.env.IDA_MCP_IDLE_TIMEOUT }
+          : {}),
       },
     });
 

--- a/ida_mcp/cli.py
+++ b/ida_mcp/cli.py
@@ -1,8 +1,79 @@
 """Command-line proxy for the IDA Nexus MCP server."""
 
+import argparse
+import math
+import os
+import sys
+
 from ida_nexus.cli.mcp import cli
 
+from ida_mcp.idle import DEFAULT_IDLE_TIMEOUT_SECONDS, install_idle_release
 
-def main() -> int:
-    """Run the IDA Nexus MCP server."""
-    return cli()
+IDLE_TIMEOUT_ENVIRONMENT_VARIABLE = "IDA_MCP_IDLE_TIMEOUT"
+_DISABLED_VALUES = {"0", "off", "none", "never", "disabled"}
+
+IDLE_TIMEOUT_HELP = f"""ida-mcp options:
+  --idle-timeout SECONDS
+                        Release the lease on a database that has not been used
+                        for this long, letting its idalib worker save, close
+                        the IDB, and exit. The database reopens transparently
+                        on its next use. GUI databases are never released.
+                        "off" disables this. Defaults to
+                        {DEFAULT_IDLE_TIMEOUT_SECONDS:g} seconds, or to
+                        ${IDLE_TIMEOUT_ENVIRONMENT_VARIABLE} when it is set.
+"""
+
+
+def _parse_idle_timeout(value: str) -> float:
+    """Parse a timeout in seconds, where a disabling word means zero."""
+    text = value.strip().casefold()
+    if text in _DISABLED_VALUES:
+        return 0.0
+    seconds = float(text)
+    if not math.isfinite(seconds) or seconds < 0:
+        raise ValueError("idle timeout must be a non-negative number of seconds")
+    return seconds
+
+
+def _resolve_idle_timeout(argument: str | None) -> float:
+    if argument is not None:
+        try:
+            return _parse_idle_timeout(argument)
+        except ValueError:
+            print(
+                f"ida-mcp: invalid --idle-timeout value: {argument!r}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2) from None
+
+    configured = os.environ.get(IDLE_TIMEOUT_ENVIRONMENT_VARIABLE)
+    # Agent hosts pass declared-but-unset variables through as empty strings.
+    if not configured or not configured.strip():
+        return DEFAULT_IDLE_TIMEOUT_SECONDS
+    try:
+        return _parse_idle_timeout(configured)
+    except ValueError:
+        print(
+            f"ida-mcp: ignoring invalid {IDLE_TIMEOUT_ENVIRONMENT_VARIABLE}="
+            f"{configured!r}",
+            file=sys.stderr,
+        )
+        return DEFAULT_IDLE_TIMEOUT_SECONDS
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the IDA Nexus MCP server with idle database release enabled."""
+    arguments = list(sys.argv[1:] if argv is None else argv)
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--idle-timeout", default=None)
+    known, remaining = parser.parse_known_args(arguments)
+
+    if "-h" in remaining or "--help" in remaining:
+        # ida-nexus prints its own help and exits from cli() below.
+        print(IDLE_TIMEOUT_HELP)
+
+    # --report-session is a PreToolUse hook that never serves a database.
+    if not any(item.startswith("--report-session") for item in remaining):
+        install_idle_release(_resolve_idle_timeout(known.idle_timeout))
+    return cli(remaining)

--- a/ida_mcp/idle.py
+++ b/ida_mcp/idle.py
@@ -1,0 +1,642 @@
+"""Release idle IDA Nexus database leases from the MCP server.
+
+An MCP server holds one IDA Nexus lease per database it has opened, and a
+managed idalib worker stays alive for as long as any lease exists. An agent
+that opens a database and never closes it therefore pins an IDA process, and
+its IDB, for the lifetime of the agent session.
+
+Two things follow from that. The machine running the MCP server can never be
+suspended while an agent is merely idle, and an unpacked IDB stays open on
+disk far longer than the work needs it, so a crash or a host shutdown has a
+much wider window in which to leave that database behind.
+
+Lease lifetime is coordinated here rather than inside the worker: a worker is
+shared by any number of clients and cannot tell which of them are still doing
+useful work. The MCP server can, because every tool call passes through it.
+
+``IdleDatabaseManager`` releases the lease on any idalib database that has not
+been used for ``idle_timeout`` seconds. The worker then saves and closes its
+IDB and exits on its own, exactly as it does for an explicit
+``close_database()``. The next tool call that names that database reattaches
+it under the *same* MCP-local ``instance_id``, so agents never observe the
+release: released databases keep their identity, keep appearing in
+``list_databases()``, and keep accepting operations.
+
+GUI databases are never released. A GUI instance is not kept alive by leases,
+so releasing one frees nothing and only costs a reattach later.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+import threading
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+from ida_nexus import (
+    CloseDatabaseResult,
+    DatabaseListing,
+    DatabaseManager,
+    ListDatabasesResult,
+    OpenDatabaseResult,
+    PythonExecutionResult,
+    SaveDatabaseResult,
+    WaitAutoanalysisResult,
+)
+
+DEFAULT_IDLE_TIMEOUT_SECONDS = 1800.0
+MIN_TICK_SECONDS = 5.0
+MAX_TICK_SECONDS = 60.0
+TICK_DIVISOR = 10.0
+
+# Ordering used by DatabaseManager.list_databases(); reapplied after released
+# databases are merged back into the listing.
+_STATUS_ORDER = {"current": 0, "attached": 1, "available": 2, "unavailable": 3}
+
+
+@dataclass
+class _ReleasedDatabase:
+    """A database whose lease was released, presented to agents as attached."""
+
+    instance_id: str
+    requested_path: str
+    listing_path: str
+    backend: str
+    was_current: bool
+    released_at: float
+
+
+class IdleDatabaseManager(DatabaseManager):
+    """A database manager that releases leases agents have stopped using.
+
+    The release is invisible to MCP clients. ``instance_id`` values survive it,
+    so an agent that comes back to a database after an hour simply waits a
+    little longer for its next tool call while the worker is reopened.
+    """
+
+    def __init__(
+        self,
+        *,
+        idle_timeout: float = DEFAULT_IDLE_TIMEOUT_SECONDS,
+        time_source: Callable[[], float] = time.monotonic,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        if (
+            isinstance(idle_timeout, bool)
+            or not isinstance(idle_timeout, (int, float))
+            or not math.isfinite(idle_timeout)
+            or idle_timeout <= 0
+        ):
+            raise ValueError("idle_timeout must be a positive finite number")
+        self._idle_timeout = float(idle_timeout)
+        self._now = time_source
+        self._idle_lock = threading.RLock()
+        self._last_touch: dict[str, float] = {}
+        self._inflight: dict[str, int] = {}
+        self._released: dict[str, _ReleasedDatabase] = {}
+        self._releasing: dict[str, threading.Event] = {}
+        # The thread performing a release passes straight through
+        # _ensure_attached(): its own close_database() call resolves the
+        # session it is about to close.
+        self._releasing_threads: dict[str, int] = {}
+        self._reattach_locks: dict[str, threading.Lock] = {}
+        # Instance ids agents have been given. Anything else is an internal id
+        # that exists only between a reattaching open and its rename.
+        self._known_ids: set[str] = set()
+        self._client_current: str | None = None
+        self._wake = threading.Event()
+        self._stop = threading.Event()
+        self._reaper: threading.Thread | None = None
+
+    # -- activity bookkeeping ------------------------------------------------
+
+    def _touch(self, instance_id: str) -> None:
+        with self._idle_lock:
+            self._last_touch[instance_id] = self._now()
+
+    def _forget(self, instance_id: str) -> None:
+        with self._idle_lock:
+            self._last_touch.pop(instance_id, None)
+            self._inflight.pop(instance_id, None)
+            self._released.pop(instance_id, None)
+            self._reattach_locks.pop(instance_id, None)
+            self._known_ids.discard(instance_id)
+            if self._client_current == instance_id:
+                self._client_current = None
+
+    def _note_current(self, instance_id: str, *, set_current: bool) -> None:
+        with self._idle_lock:
+            self._known_ids.add(instance_id)
+            if set_current or self._client_current is None:
+                self._client_current = instance_id
+
+    def _peek_current(self) -> str | None:
+        with self._idle_lock:
+            return self._client_current
+
+    @contextmanager
+    def _busy(self, instance_id: str | None) -> Iterator[str]:
+        """Resolve a target and mark it in use for the length of an operation.
+
+        A long execution is activity even though it stamps the clock only at
+        its start and end, so the reaper must never release a database with an
+        operation in flight.
+        """
+        target_id, _ = self._get_session(instance_id)
+        with self._idle_lock:
+            self._inflight[target_id] = self._inflight.get(target_id, 0) + 1
+        try:
+            yield target_id
+        finally:
+            with self._idle_lock:
+                remaining = self._inflight.get(target_id, 1) - 1
+                if remaining > 0:
+                    self._inflight[target_id] = remaining
+                else:
+                    self._inflight.pop(target_id, None)
+                self._last_touch[target_id] = self._now()
+
+    # -- release and reattach ------------------------------------------------
+
+    def _reattach_lock(self, instance_id: str) -> threading.Lock:
+        with self._idle_lock:
+            lock = self._reattach_locks.get(instance_id)
+            if lock is None:
+                lock = threading.Lock()
+                self._reattach_locks[instance_id] = lock
+            return lock
+
+    def _adopt(self, new_id: str, instance_id: str) -> None:
+        """Rebind a freshly opened session under its original instance id."""
+        if new_id == instance_id:
+            return
+        with self._lock:
+            session = self._instances.pop(new_id, None)
+            if session is None:
+                return
+            session.instance_id = instance_id
+            self._instances[instance_id] = session
+            if self._current_instance_id == new_id:
+                self._current_instance_id = instance_id
+        with self._idle_lock:
+            self._last_touch.pop(new_id, None)
+            self._known_ids.discard(new_id)
+            self._last_touch[instance_id] = self._now()
+            self._known_ids.add(instance_id)
+
+    def _reattach(self, released: _ReleasedDatabase) -> None:
+        instance_id = released.instance_id
+        try:
+            result = super().open_database(
+                released.requested_path,
+                set_current=released.was_current,
+            )
+        except BaseException:
+            # Leave the database released so a later call can try again. The
+            # agent sees the underlying open failure, which is the same error
+            # it would have seen from open_database().
+            with self._idle_lock:
+                self._released.setdefault(instance_id, released)
+            raise
+        self._adopt(result["instance_id"], instance_id)
+        # open_database() may have chosen its own current target while this
+        # database had none; the agent's current target is authoritative.
+        if self._peek_current() == instance_id:
+            with self._lock:
+                if instance_id in self._instances:
+                    self._current_instance_id = instance_id
+        self._emit(
+            "database_reattached",
+            instance_id=instance_id,
+            path=released.requested_path,
+            released_seconds=round(self._now() - released.released_at, 3),
+        )
+
+    def _ensure_attached(self, instance_id: str) -> None:
+        """Wait out an in-progress release, then reattach if one happened."""
+        while True:
+            with self._idle_lock:
+                releasing = self._releasing.get(instance_id)
+                owner = self._releasing_threads.get(instance_id)
+                released = self._released.get(instance_id)
+            if releasing is not None:
+                if owner == threading.get_ident():
+                    return
+                releasing.wait(self._open_timeout)
+                continue
+            if released is None:
+                return
+            with self._reattach_lock(instance_id):
+                with self._idle_lock:
+                    pending = self._released.pop(instance_id, None)
+                if pending is None:
+                    # Another thread reattached it while we waited.
+                    continue
+                self._reattach(pending)
+            return
+
+    def _release(self, instance_id: str, idle_for: float) -> None:
+        """Release one idle lease and remember how to bring it back."""
+        with self._lock:
+            session = self._instances.get(instance_id)
+            if session is None:
+                return
+            entry = session.handle.instance
+            requested_path = session.requested_path
+            was_current = self._current_instance_id == instance_id
+        released = _ReleasedDatabase(
+            instance_id=instance_id,
+            requested_path=requested_path,
+            listing_path=self._listing_path(entry),
+            backend=entry.backend,
+            was_current=was_current,
+            released_at=self._now(),
+        )
+        done = threading.Event()
+        with self._idle_lock:
+            if instance_id in self._releasing or instance_id in self._released:
+                return
+            self._releasing[instance_id] = done
+            self._releasing_threads[instance_id] = threading.get_ident()
+        try:
+            # close_database() drops the lease and waits for the worker to save
+            # and close its IDB, so a reattach cannot race a draining worker.
+            super().close_database(instance_id)
+        except Exception as error:  # noqa: BLE001 - the lease is gone either way
+            self._emit(
+                "database_idle_release_error",
+                instance_id=instance_id,
+                error=error,
+            )
+        finally:
+            with self._idle_lock:
+                # An agent that closed this database while the release was in
+                # flight has already given up its id; do not resurrect it.
+                if instance_id in self._known_ids:
+                    self._released[instance_id] = released
+                self._releasing.pop(instance_id, None)
+                self._releasing_threads.pop(instance_id, None)
+                self._inflight.pop(instance_id, None)
+                self._last_touch.pop(instance_id, None)
+            done.set()
+        self._emit(
+            "database_idle_released",
+            instance_id=instance_id,
+            path=requested_path,
+            idle_seconds=round(idle_for, 3),
+            idle_timeout=self._idle_timeout,
+        )
+
+    # -- reaper --------------------------------------------------------------
+
+    def _tick(self) -> None:
+        """Release every lease that has been idle past the timeout."""
+        now = self._now()
+        with self._lock:
+            sessions = list(self._instances.values())
+        live_ids = {session.instance_id for session in sessions}
+        with self._idle_lock:
+            for stale in set(self._last_touch) - live_ids:
+                if stale not in self._released and stale not in self._releasing:
+                    self._last_touch.pop(stale, None)
+            busy = {
+                instance_id
+                for instance_id, count in self._inflight.items()
+                if count > 0
+            }
+            touches = dict(self._last_touch)
+            pending = set(self._releasing) | set(self._released)
+
+        for session in sessions:
+            instance_id = session.instance_id
+            if instance_id in busy or instance_id in pending:
+                continue
+            handle = session.handle
+            # A GUI database is not kept alive by our lease; releasing it frees
+            # nothing and only makes the next call slower.
+            if handle.instance.backend != "idalib" or not handle.connected:
+                continue
+            idle_for = now - touches.get(instance_id, now)
+            if idle_for < self._idle_timeout:
+                continue
+            if not self._analysis_settled(session):
+                self._touch(instance_id)
+                continue
+            self._release(instance_id, idle_for)
+
+    def _analysis_settled(self, session: Any) -> bool:
+        """Report whether initial autoanalysis has finished.
+
+        Releasing during the first analysis would throw away work the agent is
+        about to ask for, so an analysing database is treated as active.
+        """
+        if session.autoanalysis_complete:
+            return True
+        try:
+            complete = bool(session.handle.poll_autoanalysis()["complete"])
+        except Exception:  # noqa: BLE001 - an unreachable worker is not ours to reap
+            return False
+        if complete:
+            session.autoanalysis_complete = True
+        return complete
+
+    def _next_wait(self) -> float | None:
+        """Seconds until the next tick, or None to sleep until woken.
+
+        With nothing attached there is nothing to reap, so the reaper parks
+        instead of waking periodically and the host can suspend cleanly.
+        """
+        with self._lock:
+            if not self._instances:
+                return None
+        return min(
+            max(self._idle_timeout / TICK_DIVISOR, MIN_TICK_SECONDS), MAX_TICK_SECONDS
+        )
+
+    def _reap_loop(self) -> None:
+        while not self._stop.is_set():
+            self._wake.wait(self._next_wait())
+            self._wake.clear()
+            if self._stop.is_set():
+                return
+            try:
+                self._tick()
+            except Exception as error:  # noqa: BLE001 - never kill the reaper
+                print(f"idle database release failed: {error}", file=sys.stderr)
+
+    def _start_reaper(self) -> None:
+        with self._idle_lock:
+            if self._stop.is_set():
+                return
+            if self._reaper is None:
+                self._reaper = threading.Thread(
+                    target=self._reap_loop,
+                    name="ida-mcp-idle-release",
+                    daemon=True,
+                )
+                self._reaper.start()
+        self._wake.set()
+
+    # -- DatabaseManager surface ---------------------------------------------
+
+    def _get_session(self, instance_id: str | None) -> tuple[str, Any]:
+        wanted = instance_id if instance_id is not None else self._peek_current()
+        if wanted is not None:
+            self._ensure_attached(wanted)
+        target = instance_id
+        if target is None and wanted is not None:
+            # Name the agent's current target explicitly: reattaching it may
+            # have left the base manager pointing at a different database.
+            with self._lock:
+                if wanted in self._instances:
+                    target = wanted
+        target_id, session = super()._get_session(target)
+        self._touch(target_id)
+        return target_id, session
+
+    def open_database(self, path: str, *, set_current: bool) -> OpenDatabaseResult:
+        result = super().open_database(path, set_current=set_current)
+        instance_id = result["instance_id"]
+        # Reopening a released database must return the id the agent already
+        # has, so match the canonical path the base manager recorded for it.
+        with self._lock:
+            session = self._instances.get(instance_id)
+            requested_path = session.requested_path if session is not None else None
+        if requested_path is not None:
+            with self._idle_lock:
+                previous = next(
+                    (
+                        released
+                        for released in self._released.values()
+                        if released.requested_path == requested_path
+                    ),
+                    None,
+                )
+                if previous is not None:
+                    self._released.pop(previous.instance_id, None)
+            if previous is not None:
+                self._adopt(instance_id, previous.instance_id)
+                instance_id = previous.instance_id
+                result = OpenDatabaseResult(
+                    instance_id=instance_id,
+                    backend=result["backend"],
+                    status=result["status"],
+                )
+        self._note_current(instance_id, set_current=set_current)
+        self._touch(instance_id)
+        self._start_reaper()
+        return result
+
+    def execute_python(
+        self,
+        code: str,
+        instance_id: str | None,
+        timeout: float | None = None,
+        *,
+        operation_id: str | None = None,
+        operation_label: str | None = None,
+        persist_globals: bool = False,
+        filename: str | None = None,
+    ) -> PythonExecutionResult:
+        with self._busy(instance_id) as target_id:
+            return super().execute_python(
+                code,
+                target_id,
+                timeout,
+                operation_id=operation_id,
+                operation_label=operation_label,
+                persist_globals=persist_globals,
+                filename=filename,
+            )
+
+    def wait_autoanalysis(
+        self,
+        instance_id: str | None,
+        timeout: float | None = None,
+        *,
+        operation_id: str | None = None,
+    ) -> WaitAutoanalysisResult:
+        with self._busy(instance_id) as target_id:
+            return super().wait_autoanalysis(
+                target_id,
+                timeout,
+                operation_id=operation_id,
+            )
+
+    def save_database(self, instance_id: str | None) -> SaveDatabaseResult:
+        with self._busy(instance_id) as target_id:
+            return super().save_database(target_id)
+
+    def cancel_operation(self, instance_id: str, operation_id: str) -> bool:
+        if self._is_released(instance_id):
+            return False
+        return super().cancel_operation(instance_id, operation_id)
+
+    def cancel_active(self, instance_id: str | None) -> bool:
+        if self._is_released(instance_id if instance_id else self._peek_current()):
+            return False
+        return super().cancel_active(instance_id)
+
+    def _is_released(self, instance_id: str | None) -> bool:
+        """Report whether a target has no lease, without reattaching it.
+
+        Cancelling an operation on a database whose worker is gone is a no-op;
+        reopening it to say so would be absurd.
+        """
+        if instance_id is None:
+            return False
+        with self._idle_lock:
+            return instance_id in self._released or instance_id in self._releasing
+
+    def close_database(self, instance_id: str | None) -> CloseDatabaseResult:
+        wanted = instance_id if instance_id is not None else self._peek_current()
+        if wanted is not None:
+            with self._idle_lock:
+                releasing = self._releasing.get(wanted)
+            if releasing is not None:
+                releasing.wait(self._open_timeout)
+            with self._idle_lock:
+                released = self._released.get(wanted)
+            if released is not None:
+                # The lease is already gone and the IDB is already closed.
+                # Reopening a worker just to close it would be worse than
+                # pointless.
+                self._forget(wanted)
+                return CloseDatabaseResult(closed=True)
+        target_id, _ = self._get_session(instance_id)
+        try:
+            return super().close_database(target_id)
+        finally:
+            self._forget(target_id)
+
+    def list_databases(self) -> ListDatabasesResult:
+        result = super().list_databases()
+        with self._idle_lock:
+            released = list(self._released.values())
+            current = self._client_current
+            known = set(self._known_ids)
+        entries = list(result["instances"])
+        for entry in entries:
+            # An id minted by a reattaching open is internal until it is
+            # renamed. Never show one to an agent.
+            if entry["instance_id"] is not None and entry["instance_id"] not in known:
+                entry["instance_id"] = None
+                entry["status"] = "available"
+        for item in released:
+            status = "current" if item.instance_id == current else "attached"
+            match = next(
+                (
+                    entry
+                    for entry in entries
+                    if entry["path"] == item.listing_path
+                    and entry["instance_id"] is None
+                ),
+                None,
+            )
+            if match is not None:
+                match["instance_id"] = item.instance_id
+                match["status"] = status
+                match["error"] = None
+                continue
+            entries.append(
+                DatabaseListing(
+                    path=item.listing_path,
+                    backend=item.backend,
+                    status=status,
+                    instance_id=item.instance_id,
+                    error=None,
+                )
+            )
+        entries.sort(
+            key=lambda item: (
+                _STATUS_ORDER[item["status"]],
+                item["backend"] != "gui",
+                item["path"],
+            )
+        )
+        return {"instances": entries}
+
+    def shutdown(self) -> None:
+        self._stop.set()
+        self._wake.set()
+        reaper = self._reaper
+        if reaper is not None and reaper is not threading.current_thread():
+            reaper.join(timeout=5.0)
+        with self._idle_lock:
+            self._released.clear()
+            self._releasing.clear()
+            self._releasing_threads.clear()
+            self._last_touch.clear()
+            self._inflight.clear()
+            self._known_ids.clear()
+            self._client_current = None
+        super().shutdown()
+
+
+_REQUIRED_INSTANCE_ATTRIBUTES = (
+    "_get_session",
+    "_instances",
+    "_lock",
+    "_current_instance_id",
+    "_open_timeout",
+    "_listing_path",
+    "_emit",
+)
+
+
+def _nexus_supports_idle_release() -> str | None:
+    """Return None when this ida-nexus exposes what the subclass needs."""
+    try:
+        probe = DatabaseManager()
+    except Exception as error:  # noqa: BLE001 - report, never fail startup
+        return f"DatabaseManager() could not be constructed: {error}"
+    missing = [
+        name for name in _REQUIRED_INSTANCE_ATTRIBUTES if not hasattr(probe, name)
+    ]
+    if missing:
+        return f"ida-nexus DatabaseManager is missing {', '.join(missing)}"
+    return None
+
+
+def install_idle_release(idle_timeout: float) -> bool:
+    """Install idle lease release into the ida-nexus MCP server.
+
+    The MCP tools resolve ``DATABASE_MANAGER`` from their module at call time,
+    so replacing it before the server starts is enough. Returns whether idle
+    release is active; an ida-nexus that no longer offers the seam this
+    subclass needs disables the feature instead of breaking the server.
+    """
+    if idle_timeout <= 0:
+        return False
+
+    from ida_nexus.cli import mcp as nexus_mcp
+
+    problem = _nexus_supports_idle_release()
+    if problem is not None:
+        print(
+            f"WARNING: idle database release is disabled: {problem}",
+            file=sys.stderr,
+        )
+        return False
+
+    try:
+        manager = IdleDatabaseManager(
+            idle_timeout=idle_timeout,
+            on_event=nexus_mcp._trace_database_event,
+            open_timeout=nexus_mcp.OPEN_TIMEOUT_SECONDS,
+            execute_timeout=nexus_mcp.EXECUTE_TIMEOUT_SECONDS,
+        )
+    except Exception as error:  # noqa: BLE001 - report, never fail startup
+        print(
+            f"WARNING: idle database release is disabled: {error}",
+            file=sys.stderr,
+        )
+        return False
+
+    nexus_mcp.DATABASE_MANAGER = manager
+    return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,12 @@ dependencies = [
 [project.scripts]
 ida-mcp = "ida_mcp.cli:main"
 
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "ruff>=0.12.0",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -23,3 +29,10 @@ only-include = [
     "ida_mcp_plugin.py",
     "ida_mcp",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.pyright]
+# IDAPython modules provide type information but are importable only inside IDA.
+reportMissingModuleSource = "none"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fakes import FakeClock, FakeHandle, FakeWorld
+
+# ida-nexus resolves its state directory at import time; keep tests out of the
+# developer's real IDA state.
+_STATE_DIR = tempfile.mkdtemp(prefix="ida-mcp-tests-")
+os.environ["IDA_NEXUS_STATE_DIR"] = _STATE_DIR
+
+
+def pytest_sessionfinish(session: object, exitstatus: int) -> None:
+    del session, exitstatus
+    shutil.rmtree(_STATE_DIR, ignore_errors=True)
+
+
+@pytest.fixture
+def world(monkeypatch: pytest.MonkeyPatch) -> FakeWorld:
+    fake = FakeWorld()
+
+    class FakeDatabaseHandle:
+        @staticmethod
+        def open(path: str, **kwargs: Any) -> FakeHandle:
+            return fake.open(path, **kwargs)
+
+    monkeypatch.setattr("ida_nexus.manager.DatabaseHandle", FakeDatabaseHandle)
+    monkeypatch.setattr("ida_nexus.manager.scan_instances", lambda *a, **k: [])
+    return fake
+
+
+@pytest.fixture
+def clock() -> FakeClock:
+    return FakeClock()
+
+
+@pytest.fixture
+def paths(tmp_path: Path) -> SimpleNamespace:
+    """Canonical paths, since the manager canonicalizes what it is given."""
+    base = tmp_path.resolve()
+    return SimpleNamespace(
+        **{
+            name: str(base / name)
+            for name in ("sample", "gui", "busy", "forgotten", "first", "second")
+        }
+    )

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,102 @@
+"""A fake Nexus transport: no IDA, no workers, and a hand-driven clock."""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+from ida_nexus._registry import DatabaseInstance
+
+IDLE_TIMEOUT = 60.0
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 1000.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class FakeHandle:
+    """The parts of DatabaseHandle that DatabaseManager actually uses."""
+
+    def __init__(self, world: FakeWorld, path: str, record_id: str) -> None:
+        self._world = world
+        self.requested_path = path
+        self.connected = True
+        self.disconnect_reason: str | None = None
+        self.closed = False
+        self.close_calls: list[bool] = []
+        self.analysis_complete = world.analysis_complete
+        self.instance = DatabaseInstance(
+            record_id=record_id,
+            backend=world.backend_for(path),
+            pid=4242,
+            port=1024,
+            _token="token",
+            version=7,
+            idb_path=f"{path}.i64",
+            idb_key=f"{abs(hash(path)):016x}"[:16],
+            exe_path="",
+            managed=True,
+            started_at=0.0,
+        )
+        self.executed: list[str] = []
+
+    def set_disconnect_callback(self, callback: Any) -> None:
+        self._disconnect = callback
+
+    def close(self, *, wait_for_database: bool = False, timeout: float = 0.0) -> None:
+        self.closed = True
+        self.connected = False
+        self.close_calls.append(wait_for_database)
+        self._world.live.pop(self.requested_path, None)
+
+    def execute_python(self, code: str, **kwargs: Any) -> dict[str, Any]:
+        self.executed.append(code)
+        return {"result": code, "stdout": "", "stderr": ""}
+
+    def save_database(self) -> dict[str, Any]:
+        return {"saved": True, "idb_path": self.instance.idb_path}
+
+    def poll_autoanalysis(self) -> dict[str, Any]:
+        return {
+            "status": "complete" if self.analysis_complete else "running",
+            "complete": self.analysis_complete,
+        }
+
+    def wait_autoanalysis(self, timeout: Any = None, **kwargs: Any) -> dict[str, Any]:
+        return self.poll_autoanalysis()
+
+    def cancel_operation(self, operation_id: str) -> bool:
+        return True
+
+    def cancel_active(self) -> bool:
+        return True
+
+
+class FakeWorld:
+    """A stand-in registry: one live handle per path, spawned on demand."""
+
+    def __init__(self) -> None:
+        self.live: dict[str, FakeHandle] = {}
+        self.opens: list[str] = []
+        self.record_ids = itertools.count(1)
+        self.gui_paths: set[str] = set()
+        self.analysis_complete = True
+        self.open_error: Exception | None = None
+
+    def backend_for(self, path: str) -> str:
+        return "gui" if path in self.gui_paths else "idalib"
+
+    def open(self, path: str, *, options: Any = None, **kwargs: Any) -> FakeHandle:
+        self.opens.append(path)
+        if self.open_error is not None:
+            raise self.open_error
+        handle = FakeHandle(self, path, f"{next(self.record_ids)}-abcdef")
+        self.live[path] = handle
+        return handle

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,160 @@
+"""Tests for the ida-mcp command line and idle-release installation."""
+
+from __future__ import annotations
+
+import pytest
+from ida_nexus.cli import mcp as nexus_mcp
+from ida_nexus.manager import DatabaseManager
+
+from ida_mcp import cli as ida_mcp_cli
+from ida_mcp.idle import (
+    DEFAULT_IDLE_TIMEOUT_SECONDS,
+    IdleDatabaseManager,
+    install_idle_release,
+)
+
+
+@pytest.fixture(autouse=True)
+def restore_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the module-global manager swap contained to one test."""
+    monkeypatch.setattr(
+        nexus_mcp,
+        "DATABASE_MANAGER",
+        nexus_mcp.DATABASE_MANAGER,
+        raising=True,
+    )
+    monkeypatch.delenv(ida_mcp_cli.IDLE_TIMEOUT_ENVIRONMENT_VARIABLE, raising=False)
+
+
+@pytest.fixture
+def served(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
+    forwarded: list[list[str]] = []
+    monkeypatch.setattr(
+        ida_mcp_cli,
+        "cli",
+        lambda argv: forwarded.append(list(argv)) or 0,
+    )
+    return forwarded
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("900", 900.0),
+        (" 1800 ", 1800.0),
+        ("0", 0.0),
+        ("off", 0.0),
+        ("None", 0.0),
+    ],
+)
+def test_idle_timeout_values(text: str, expected: float) -> None:
+    assert ida_mcp_cli._parse_idle_timeout(text) == expected
+
+
+@pytest.mark.parametrize("text", ["-1", "later", "inf", "nan", ""])
+def test_invalid_idle_timeout_values(text: str) -> None:
+    with pytest.raises(ValueError):
+        ida_mcp_cli._parse_idle_timeout(text)
+
+
+def test_idle_timeout_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert ida_mcp_cli._resolve_idle_timeout(None) == DEFAULT_IDLE_TIMEOUT_SECONDS
+
+
+def test_empty_environment_variable_uses_the_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Agent hosts forward declared-but-unset variables as empty strings; that
+    # must not silently disable idle release.
+    monkeypatch.setenv(ida_mcp_cli.IDLE_TIMEOUT_ENVIRONMENT_VARIABLE, "")
+    assert ida_mcp_cli._resolve_idle_timeout(None) == DEFAULT_IDLE_TIMEOUT_SECONDS
+
+
+def test_environment_variable_sets_the_idle_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(ida_mcp_cli.IDLE_TIMEOUT_ENVIRONMENT_VARIABLE, "120")
+    assert ida_mcp_cli._resolve_idle_timeout(None) == 120.0
+
+
+def test_flag_overrides_the_environment_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(ida_mcp_cli.IDLE_TIMEOUT_ENVIRONMENT_VARIABLE, "120")
+    assert ida_mcp_cli._resolve_idle_timeout("300") == 300.0
+
+
+def test_invalid_environment_variable_falls_back_to_the_default(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setenv(ida_mcp_cli.IDLE_TIMEOUT_ENVIRONMENT_VARIABLE, "soon")
+    assert ida_mcp_cli._resolve_idle_timeout(None) == DEFAULT_IDLE_TIMEOUT_SECONDS
+    assert "ignoring invalid" in capsys.readouterr().err
+
+
+def test_invalid_flag_is_rejected(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as error:
+        ida_mcp_cli._resolve_idle_timeout("soon")
+    assert error.value.code == 2
+    assert "invalid --idle-timeout" in capsys.readouterr().err
+
+
+def test_main_installs_idle_release_and_forwards_the_rest(
+    served: list[list[str]],
+) -> None:
+    assert ida_mcp_cli.main(["--idle-timeout=300", "--agent=claude"]) == 0
+
+    assert served == [["--agent=claude"]]
+    manager = nexus_mcp.DATABASE_MANAGER
+    assert isinstance(manager, IdleDatabaseManager)
+    assert manager._idle_timeout == 300.0
+    assert manager._open_timeout == nexus_mcp.OPEN_TIMEOUT_SECONDS
+    assert manager._execute_timeout == nexus_mcp.EXECUTE_TIMEOUT_SECONDS
+
+
+def test_main_can_disable_idle_release(served: list[list[str]]) -> None:
+    original = nexus_mcp.DATABASE_MANAGER
+
+    assert ida_mcp_cli.main(["--idle-timeout", "off"]) == 0
+
+    assert served == [[]]
+    assert nexus_mcp.DATABASE_MANAGER is original
+
+
+def test_report_session_hook_does_not_install_a_manager(
+    served: list[list[str]],
+) -> None:
+    original = nexus_mcp.DATABASE_MANAGER
+
+    assert ida_mcp_cli.main(["--report-session=claude"]) == 0
+
+    assert served == [["--report-session=claude"]]
+    assert nexus_mcp.DATABASE_MANAGER is original
+
+
+def test_install_is_skipped_when_ida_nexus_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    original = nexus_mcp.DATABASE_MANAGER
+    monkeypatch.setattr(
+        "ida_mcp.idle._nexus_supports_idle_release",
+        lambda: "DatabaseManager is missing _get_session",
+    )
+
+    assert install_idle_release(300.0) is False
+
+    assert nexus_mcp.DATABASE_MANAGER is original
+    assert isinstance(nexus_mcp.DATABASE_MANAGER, DatabaseManager)
+    assert "idle database release is disabled" in capsys.readouterr().err
+
+
+def test_installing_does_not_change_the_mcp_tool_surface(
+    served: list[list[str]],
+) -> None:
+    before = nexus_mcp.mcp._mcp_tools_list()
+
+    assert ida_mcp_cli.main(["--idle-timeout=300"]) == 0
+
+    assert nexus_mcp.mcp._mcp_tools_list() == before

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -1,0 +1,383 @@
+"""Tests for idle database release.
+
+These exercise ``IdleDatabaseManager`` against a fake Nexus transport: no IDA,
+no worker processes, and a clock the test advances by hand. The reaper thread
+is never started; ``_tick()`` is called directly so the tests are deterministic.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fakes import IDLE_TIMEOUT, FakeClock, FakeWorld
+from ida_nexus import DatabaseSelectionError
+from ida_nexus.manager import DatabaseManager
+
+from ida_mcp.idle import IdleDatabaseManager
+
+
+@pytest.fixture
+def manager(world: FakeWorld, clock: FakeClock) -> IdleDatabaseManager:
+    return IdleDatabaseManager(idle_timeout=IDLE_TIMEOUT, time_source=clock)
+
+
+def open_and_idle(
+    manager: IdleDatabaseManager,
+    clock: FakeClock,
+    path: str,
+) -> str:
+    instance_id = manager.open_database(path, set_current=True)["instance_id"]
+    clock.advance(IDLE_TIMEOUT + 1)
+    manager._tick()
+    return instance_id
+
+
+def test_idle_database_is_released(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    instance_id = manager.open_database(paths.sample, set_current=True)["instance_id"]
+    handle = world.live[paths.sample]
+
+    clock.advance(IDLE_TIMEOUT + 1)
+    manager._tick()
+
+    assert handle.closed
+    # The lease release waits for the worker to finish closing its IDB.
+    assert handle.close_calls == [True]
+    assert instance_id in manager._released
+
+
+def test_release_keeps_the_instance_id_and_reattaches_transparently(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    instance_id = open_and_idle(manager, clock, paths.sample)
+
+    result = manager.execute_python("1 + 1", instance_id)
+
+    assert result["result"] == "1 + 1"
+    assert world.opens == [paths.sample, paths.sample]
+    assert manager.resolve_instance_id(instance_id) == instance_id
+    assert instance_id not in manager._released
+
+
+def test_current_target_survives_a_release(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    instance_id = open_and_idle(manager, clock, paths.sample)
+
+    manager.execute_python("db", None)
+
+    assert manager.resolve_instance_id(None) == instance_id
+    assert manager._current_instance_id == instance_id
+
+
+def test_a_second_database_does_not_steal_the_current_target(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    first = manager.open_database(paths.first, set_current=True)["instance_id"]
+    manager.open_database(paths.second, set_current=False)
+    clock.advance(IDLE_TIMEOUT + 1)
+    manager._tick()
+
+    # Both are idle, so both are released; the current target must come back
+    # as the current target.
+    assert manager.resolve_instance_id(None) == first
+
+
+def test_forgotten_database_is_released_while_another_stays_in_use(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    busy = manager.open_database(paths.busy, set_current=True)["instance_id"]
+    forgotten = manager.open_database(paths.forgotten, set_current=False)["instance_id"]
+
+    for _ in range(4):
+        clock.advance(IDLE_TIMEOUT / 2)
+        manager.execute_python("db", busy)
+        manager._tick()
+
+    assert forgotten in manager._released
+    assert busy not in manager._released
+    assert world.live[paths.busy].connected
+
+
+def test_gui_databases_are_never_released(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    world.gui_paths.add(paths.gui)
+    instance_id = manager.open_database(paths.gui, set_current=True)["instance_id"]
+
+    clock.advance(IDLE_TIMEOUT * 10)
+    manager._tick()
+
+    assert manager._released == {}
+    assert world.live[paths.gui].connected
+    assert manager.resolve_instance_id(instance_id) == instance_id
+
+
+def test_active_database_is_not_released(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    instance_id = manager.open_database(paths.sample, set_current=True)["instance_id"]
+
+    clock.advance(IDLE_TIMEOUT - 1)
+    manager.execute_python("db", instance_id)
+    clock.advance(IDLE_TIMEOUT - 1)
+    manager._tick()
+
+    assert manager._released == {}
+
+
+def test_operation_in_flight_blocks_release(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    instance_id = manager.open_database(paths.sample, set_current=True)["instance_id"]
+    handle = world.live[paths.sample]
+
+    ticked = threading.Event()
+
+    def slow_execute(code: str, **kwargs: Any) -> dict[str, Any]:
+        # A long execution stamps the clock only at its edges, so the reaper
+        # must respect the in-flight count instead.
+        clock.advance(IDLE_TIMEOUT * 5)
+        manager._tick()
+        ticked.set()
+        return {"result": code, "stdout": "", "stderr": ""}
+
+    handle.execute_python = slow_execute  # type: ignore[method-assign]
+    manager.execute_python("slow", instance_id)
+
+    assert ticked.is_set()
+    assert manager._released == {}
+    assert not handle.closed
+
+
+def test_running_autoanalysis_blocks_release(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    world.analysis_complete = False
+    manager.open_database(paths.sample, set_current=True)
+
+    clock.advance(IDLE_TIMEOUT + 1)
+    manager._tick()
+    assert manager._released == {}
+
+    world.live[paths.sample].analysis_complete = True
+    clock.advance(IDLE_TIMEOUT + 1)
+    manager._tick()
+    assert manager._released != {}
+
+
+def test_released_database_is_still_listed_as_the_current_target(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    manager.open_database(paths.sample, set_current=True)
+    before = manager.list_databases()
+
+    clock.advance(IDLE_TIMEOUT + 1)
+    manager._tick()
+
+    assert manager.list_databases() == before
+
+
+def test_reopening_a_released_path_returns_the_original_id(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    instance_id = open_and_idle(manager, clock, paths.sample)
+
+    result = manager.open_database(paths.sample, set_current=True)
+
+    assert result["instance_id"] == instance_id
+    assert len(manager.list_databases()["instances"]) == 1
+
+
+def test_closing_a_released_database_does_not_reopen_it(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    instance_id = open_and_idle(manager, clock, paths.sample)
+
+    assert manager.close_database(instance_id) == {"closed": True}
+
+    assert world.opens == [paths.sample]
+    assert manager.list_databases()["instances"] == []
+    with pytest.raises(DatabaseSelectionError):
+        manager.resolve_instance_id(instance_id)
+
+
+def test_cancelling_a_released_database_is_a_noop(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    instance_id = open_and_idle(manager, clock, paths.sample)
+
+    assert manager.cancel_operation(instance_id, "operation") is False
+    assert manager.cancel_active(None) is False
+    assert world.opens == [paths.sample]
+
+
+def test_failed_reattach_leaves_the_database_recoverable(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    instance_id = open_and_idle(manager, clock, paths.sample)
+    world.open_error = RuntimeError("worker failed to start")
+
+    with pytest.raises(RuntimeError, match="worker failed to start"):
+        manager.execute_python("db", instance_id)
+
+    world.open_error = None
+    assert manager.execute_python("db", instance_id)["result"] == "db"
+
+
+def test_reaper_parks_until_a_database_is_attached(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    assert manager._next_wait() is None
+
+    manager.open_database(paths.sample, set_current=True)
+    assert manager._next_wait() == pytest.approx(6.0)
+
+    clock.advance(IDLE_TIMEOUT + 1)
+    manager._tick()
+    assert manager._next_wait() is None
+
+
+def test_reaper_thread_starts_on_open_and_stops_on_shutdown(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    paths: SimpleNamespace,
+) -> None:
+    assert manager._reaper is None
+
+    manager.open_database(paths.sample, set_current=True)
+    reaper = manager._reaper
+    assert reaper is not None and reaper.is_alive()
+
+    manager.shutdown()
+    reaper.join(timeout=5.0)
+    assert not reaper.is_alive()
+    assert not world.live
+
+
+def test_shutdown_releases_released_bookkeeping(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    open_and_idle(manager, clock, paths.sample)
+
+    manager.shutdown()
+
+    assert manager._released == {}
+    assert manager.list_databases()["instances"] == []
+
+
+def test_idle_timeout_must_be_positive(world: FakeWorld) -> None:
+    with pytest.raises(ValueError, match="idle_timeout"):
+        IdleDatabaseManager(idle_timeout=0)
+
+
+def test_manager_only_relies_on_documented_internals() -> None:
+    # The subclass reaches into DatabaseManager; fail loudly here rather than
+    # mysteriously at runtime if a future ida-nexus drops one of these.
+    probe = DatabaseManager()
+    for name in (
+        "_get_session",
+        "_instances",
+        "_lock",
+        "_current_instance_id",
+        "_open_timeout",
+        "_listing_path",
+        "_emit",
+    ):
+        assert hasattr(probe, name), name
+
+
+def test_call_during_a_release_waits_and_then_reattaches(
+    manager: IdleDatabaseManager,
+    world: FakeWorld,
+    clock: FakeClock,
+    paths: SimpleNamespace,
+) -> None:
+    instance_id = manager.open_database(paths.sample, set_current=True)["instance_id"]
+    handle = world.live[paths.sample]
+    finish_close = threading.Event()
+    closing = threading.Event()
+    original_close = handle.close
+
+    def blocking_close(**kwargs: Any) -> None:
+        closing.set()
+        assert finish_close.wait(10)
+        original_close(**kwargs)
+
+    handle.close = blocking_close  # type: ignore[method-assign]
+    clock.advance(IDLE_TIMEOUT + 1)
+
+    releasing = threading.Thread(target=manager._tick)
+    releasing.start()
+    assert closing.wait(10)
+
+    results: list[Any] = []
+    caller = threading.Thread(
+        target=lambda: results.append(manager.execute_python("db", instance_id))
+    )
+    caller.start()
+    # The database is mid-release: the call must wait rather than see a
+    # half-closed session or a missing instance.
+    time.sleep(0.05)
+    assert caller.is_alive()
+
+    finish_close.set()
+    releasing.join(10)
+    caller.join(10)
+
+    assert results == [{"result": "db", "stdout": "", "stderr": ""}]
+    assert world.opens == [paths.sample, paths.sample]
+    assert instance_id not in manager._released

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,61 @@
+"""End-to-end checks through the ida-nexus MCP tools themselves.
+
+These call the registered tool functions the way an MCP client does, with the
+Nexus transport faked out, to confirm that idle release stays invisible at the
+tool boundary and not merely inside the manager.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from fakes import IDLE_TIMEOUT, FakeClock, FakeWorld
+from ida_nexus.cli import mcp as nexus_mcp
+
+from ida_mcp.idle import IdleDatabaseManager
+
+
+@pytest.fixture
+def tools(
+    monkeypatch: pytest.MonkeyPatch,
+    world: FakeWorld,
+    clock: FakeClock,
+) -> SimpleNamespace:
+    manager = IdleDatabaseManager(idle_timeout=IDLE_TIMEOUT, time_source=clock)
+    monkeypatch.setattr(nexus_mcp, "DATABASE_MANAGER", manager)
+    return SimpleNamespace(manager=manager, module=nexus_mcp)
+
+
+def test_tools_never_observe_an_idle_release(
+    tools: SimpleNamespace,
+    world: FakeWorld,
+    clock: FakeClock,
+    tmp_path: Path,
+) -> None:
+    sample = str(tmp_path.resolve() / "sample")
+
+    opened = nexus_mcp.open_database(sample)
+    instance_id = opened["instance_id"]
+    listed = nexus_mcp.list_databases()["instances"]
+
+    clock.advance(IDLE_TIMEOUT + 1)
+    tools.manager._tick()
+
+    # The worker is gone, but nothing an agent can see has changed.
+    assert not world.live
+    assert nexus_mcp.list_databases()["instances"] == listed
+
+    result: dict[str, Any] = asyncio.run(
+        nexus_mcp.execute_python("db.entry", instance_id)
+    )
+
+    assert result["result"] == "db.entry"
+    assert world.opens == [sample, sample]
+    assert nexus_mcp.list_databases()["instances"] == listed
+    assert nexus_mcp.open_database(sample)["instance_id"] == instance_id
+    assert nexus_mcp.save_database(instance_id)["path"] == f"{sample}.i64"
+    assert nexus_mcp.close_database(instance_id) == {"closed": True}

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "ida-domain"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -24,8 +33,20 @@ dependencies = [
     { name = "ida-nexus" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "ida-nexus", specifier = ">=0.8.1" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "ruff", specifier = ">=0.12.0" },
+]
 
 [[package]]
 name = "ida-nexus"
@@ -51,12 +72,80 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/85/c8e12473c93018f92d19dd988a294202e1c27426c47ec4de53ffb847b8d8/ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b", size = 4912003, upload-time = "2026-08-27T16:34:18.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/b6/77c90a970fe2dae17a723acbd011043ea97c98d7deacccefdc4ba74ec512/ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b", size = 10011941, upload-time = "2026-08-27T16:33:41.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/46/6cf67cf6411885a1d6f7f6d801682f155536a85176d10b605e2ceffed8bd/ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3", size = 10204049, upload-time = "2026-08-27T16:33:44.056Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fd/c8720ca7a090abf0c2fef4abe8a5ef6e5127ed15196d8886ff75a2b370e2/ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb", size = 9809037, upload-time = "2026-08-27T16:33:46.257Z" },
+    { url = "https://files.pythonhosted.org/packages/43/45/a684caacdedaca180f52bacccc40bf0789d2c5a7c75f25324853e9eaedb5/ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025", size = 9964129, upload-time = "2026-08-27T16:33:48.352Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/5d2bcdaca6b5b93d1b4dfc166cd2aebf7680143a1b38a28759df13a94d31/ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9", size = 9821518, upload-time = "2026-08-27T16:33:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ff/011cce29accf9257d5974145b733fc653a37985ed6825413a3987cefbfe0/ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7", size = 10534835, upload-time = "2026-08-27T16:33:52.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5a/f0cf109bada9bba0e96c90c21c9f9251803f57225c32d293327a03c710d6/ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde", size = 11252550, upload-time = "2026-08-27T16:33:54.521Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4d/1d481aaea2046c6a7ed7c291f9004c669cce3c087b6b376ed5b08271e3fe/ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea", size = 10777949, upload-time = "2026-08-27T16:33:56.88Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/34/ee245ca55f64443233034b3d02b03236b19242004281247c079390b7facd/ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105", size = 10311656, upload-time = "2026-08-27T16:33:59.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/c33a333e341c0a2b96c715b52d89a606f5a34cd4ac493cd9b8d0187186b8/ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29", size = 10532125, upload-time = "2026-08-27T16:34:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/a64cef78b40192497bb98a27a8aa8f2c98ee9ee15bc97f7712d94ef32937/ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf", size = 10097648, upload-time = "2026-08-27T16:34:03.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4e/4cdc9ed3c3e109d2f71e62572a37457298d7bc7501ec3138babb7ed32bbd/ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91", size = 9829344, upload-time = "2026-08-27T16:34:05.134Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4a/31ed35ce31729955fc583ee0d176d6e784c1290cb0b0a75cb2134c1ab72a/ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a", size = 10277117, upload-time = "2026-08-27T16:34:07.425Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a0/60356d86687b4b666d593df213f4dc3041750d024cb7bf2cfa81cfd65c2e/ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef", size = 10711653, upload-time = "2026-08-27T16:34:09.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/20/656d67f5b25ca9bda4e02b1de25867b2954e1d19e03648060f167ad0f4cc/ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26", size = 10034250, upload-time = "2026-08-27T16:34:11.8Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/42/ee8e68a207b9127fcde6c3d7e197def432f346cb1af159e1fa14ca0d1cdc/ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f", size = 10516714, upload-time = "2026-08-27T16:34:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e3/7df5a396e445b9ba49ce9a9437439a4d80042c61c0ade199abf8d16de1ac/ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e", size = 10391564, upload-time = "2026-08-27T16:34:16.064Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
(draft)

Refs HexRaysSA/ida-nexus#47

## Why

An agent that opens a database and never closes it pins an IDA worker, and its unpacked IDB, for the whole agent session. A managed worker shuts down only when its last lease disappears, and the MCP server holds that lease until the server exits. So an idle machine can never be suspended, and a crash or host shutdown has a much wider window in which to leave a database open on disk.

Lease lifetime is coordinated here rather than in the worker: a worker is shared by any number of clients and cannot tell which of them are still doing useful work. Every tool call passes through the MCP server, so it can.

## What

`IdleDatabaseManager` (a `DatabaseManager` subclass, installed over `ida_nexus.cli.mcp.DATABASE_MANAGER` before the server starts) releases the lease on any idalib database this server has not used for 30 minutes. The worker then saves, closes its IDB, and exits on its own, exactly as it does for an explicit `close_database()`.

**The release is invisible to agents.** The next tool call that uses the database reopens it under the *same* `instance_id`: identities survive it, `list_databases()` output is unchanged, and every operation still works. Reattach goes through `open_database()` and then rebinds the session under its original id.

Never released:

- GUI databases — a GUI instance is not kept alive by MCP leases, so releasing one frees nothing.
- Databases with an operation in flight — a long `execute_python` stamps the activity clock only at its edges, so an in-flight count guards it.
- Databases still running initial autoanalysis — releasing there throws away work the agent is about to ask for.

Release waits for the worker to finish closing its IDB before the database is marked released, so a reattach cannot race a draining worker into `BLOCKED`. A call arriving mid-release waits for the release and then reattaches. With nothing attached the reaper parks rather than waking periodically, so an idle server is genuinely quiescent.

## Configuration

`--idle-timeout SECONDS` (or `IDA_MCP_IDLE_TIMEOUT`), default `1800`, `off` to disable. Forwarded through the Claude, Codex, and Pi/oh-my-pi manifests; a host that passes the variable through unset (empty string) gets the default, not "off".

## Tests

This repository had no test or lint CI, so this adds `pytest` + `ruff` dev dependencies and a `Checks` workflow alongside 42 tests. They run against a faked Nexus transport with a hand-driven clock — no IDA, no worker processes, no sleeping — covering release and same-id reattach, listing continuity, the GUI and in-flight and analysing exclusions, close/cancel on a released database, a call racing an in-progress release, reattach failure and recovery, the reaper parking, and the CLI/installation surface (including that the published MCP tool schemas are unchanged).

Not yet verified on real IDA: opening a large IDB, letting the timer fire, confirming the worker exits with a packed `.i64`, and executing again to confirm the transparent reopen.

## Notes for review

- The subclass depends on `DatabaseManager._get_session`, `_instances`, `_lock`, `_current_instance_id`, and `_DatabaseSession.instance_id`. A startup probe disables idle release with a warning on stderr instead of failing the server if a future ida-nexus drops one. A public `resolve_session()` plus a `reattach(instance_id)` in ida-nexus would remove that coupling entirely.
- MCP `execute_python` uses lease-scoped globals, which ida-nexus clears when the lease goes, so an agent's variables can reset across a release. Nothing surfaces that today, by design — the tool description in ida-nexus still promises they persist for the lease and is worth revisiting.
- The `uvx ida-nexus mcp` configuration in the README runs the ida-nexus server directly and therefore has no idle release; the README now says so.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M7w8YYAa1UW9w1jvFCXUmC)_